### PR TITLE
Extend Workspace Edit Page & Implement Suspension Billing Features

### DIFF
--- a/app/app/Console/Commands/RabbitMQEventConsumer.php
+++ b/app/app/Console/Commands/RabbitMQEventConsumer.php
@@ -51,6 +51,13 @@ class RabbitMQEventConsumer extends Command
         $channel->queue_declare(self::CALL_ACTIVITY_QUEUE, false, true, false, false);
         $channel->queue_declare(RabbitMQHelper::INVOICE_QUEUE_MONTHLY, false, true, false, false);
         $channel->queue_declare(RabbitMQHelper::INVOICE_QUEUE_ANNUAL, false, true, false, false);
+        $channel->exchange_declare(RabbitMQHelper::BILLING_EVENTS_EXCHANGE, 'topic', false, true, false);
+        $channel->queue_declare(RabbitMQHelper::WORKSPACE_SUSPENDED_QUEUE, false, true, false, false);
+        $channel->queue_bind(
+            RabbitMQHelper::WORKSPACE_SUSPENDED_QUEUE,
+            RabbitMQHelper::BILLING_EVENTS_EXCHANGE,
+            RabbitMQHelper::WORKSPACE_SUSPENDED_ROUTING_KEY
+        );
 
         $this->info(" [*] Event Consumer Online. Waiting for messages...");
 
@@ -65,6 +72,7 @@ class RabbitMQEventConsumer extends Command
         $channel->basic_consume(self::CALL_ACTIVITY_QUEUE, '', false, false, false, false, [$this, 'handleCallActivity']);
         $channel->basic_consume(RabbitMQHelper::INVOICE_QUEUE_MONTHLY, '', false, false, false, false, [$this, 'handleMonthlyInvoiceTask']);
         $channel->basic_consume(RabbitMQHelper::INVOICE_QUEUE_ANNUAL, '', false, false, false, false, [$this, 'handleAnnualInvoiceTask']);
+        $channel->basic_consume(RabbitMQHelper::WORKSPACE_SUSPENDED_QUEUE, '', false, false, false, false, [$this, 'handleWorkspaceSuspended']);
 
         // 3. Keep the process alive
         while (count($channel->callbacks)) {
@@ -387,6 +395,117 @@ class RabbitMQEventConsumer extends Command
             'workspace_id' => $workspaceId,
             'user_id' => $userId
         ]);
+    }
+
+    public function handleWorkspaceSuspended($msg)
+    {
+        $payload = json_decode($msg->body, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($payload)) {
+            $this->logConsumerError(' [WORKSPACE_SUSPENDED] Malformed JSON: ' . json_last_error_msg(), [
+                'body' => $msg->body
+            ]);
+            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            return;
+        }
+
+        if (!isset($payload['event']) || $payload['event'] !== 'workspace.suspended') {
+            $event = isset($payload['event']) ? $payload['event'] : 'missing';
+            $this->logConsumerError(' [WORKSPACE_SUSPENDED] Unsupported event: ' . $event, [
+                'payload' => $payload
+            ]);
+            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            return;
+        }
+
+        $data = isset($payload['data']) && is_array($payload['data']) ? $payload['data'] : array();
+        $workspaceId = isset($data['workspace_id']) ? (int) $data['workspace_id'] : 0;
+        if ($workspaceId <= 0) {
+            $this->logConsumerError(' [WORKSPACE_SUSPENDED] Missing workspace_id.', [
+                'payload' => $payload
+            ]);
+            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            return;
+        }
+
+        $workspace = Workspace::find($workspaceId);
+        if (!$workspace) {
+            $this->logConsumerError(sprintf(' [WORKSPACE_SUSPENDED] Workspace #%d not found.', $workspaceId));
+            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            return;
+        }
+
+        $owner = $workspace->creatorUser()->first();
+        $ownerEmail = !empty($data['owner_email']) ? $data['owner_email'] : ($owner ? $owner->email : null);
+        $adminEmail = $this->resolveSystemAdminEmail();
+
+        $emailData = array(
+            'workspace' => $workspace,
+            'owner' => $owner,
+            'event' => $payload,
+            'event_data' => $data,
+            'workspace_id' => $workspaceId,
+            'suspended_at' => isset($data['suspended_at']) ? $data['suspended_at'] : '',
+            'reason' => isset($data['reason']) ? $data['reason'] : 'payment_past_due',
+            'grace_period_extension_days' => array_key_exists('grace_period_extension_days', $data) ? $data['grace_period_extension_days'] : null
+        );
+
+        $ownerResult = TRUE;
+        if (!empty($ownerEmail)) {
+            $ownerResult = EmailHelper::sendEmail(
+                'Account Suspended: Billing Action Required',
+                $ownerEmail,
+                'workspace_account_suspended',
+                $emailData
+            );
+        } else {
+            $this->logConsumerError(sprintf(' [WORKSPACE_SUSPENDED] Owner email missing for workspace #%d.', $workspaceId));
+            $ownerResult = FALSE;
+        }
+
+        $adminResult = TRUE;
+        if (!empty($adminEmail)) {
+            $adminResult = EmailHelper::sendEmail(
+                sprintf('Workspace #%d Suspended', $workspaceId),
+                $adminEmail,
+                'workspace_suspended_admin',
+                $emailData
+            );
+        } else {
+            $this->logConsumerError(' [WORKSPACE_SUSPENDED] System admin email could not be resolved.');
+            $adminResult = FALSE;
+        }
+
+        if ($ownerResult === TRUE && $adminResult === TRUE) {
+            $this->logConsumerInfo(sprintf(' [v] Workspace suspension emails sent for workspace #%d.', $workspaceId), [
+                'workspace_id' => $workspaceId,
+                'owner_email' => $ownerEmail,
+                'admin_email' => $adminEmail
+            ]);
+            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            return;
+        }
+
+        $this->logConsumerError(sprintf(' [!] Workspace suspension email failed for workspace #%d.', $workspaceId), [
+            'workspace_id' => $workspaceId,
+            'owner_result' => $ownerResult,
+            'admin_result' => $adminResult
+        ]);
+    }
+
+    private function resolveSystemAdminEmail()
+    {
+        $admin = User::where('admin', '1')->first();
+        if ($admin && !empty($admin->email)) {
+            return $admin->email;
+        }
+
+        $customizations = \App\Customizations::getRecord();
+        if ($customizations && !empty($customizations->contact_email)) {
+            return $customizations->contact_email;
+        }
+
+        return env('ADMIN_EMAIL', env('MAIL_FROM_ADDRESS'));
     }
 
     private function isCallActivityError($data)

--- a/app/app/Console/Commands/SuspendPastDueWorkspacesCommand.php
+++ b/app/app/Console/Commands/SuspendPastDueWorkspacesCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PaymentStatus;
+use App\Helpers\WorkspaceSuspensionHelper;
+use App\UserInvoice;
+use App\Workspace;
+use DateTime;
+use Illuminate\Console\Command;
+
+class SuspendPastDueWorkspacesCommand extends Command
+{
+    protected $signature = 'billing:suspend-past-due-workspaces {--workspace_id=}';
+
+    protected $description = 'Suspend workspaces with unpaid invoices beyond their grace period';
+
+    public function handle()
+    {
+        $today = new DateTime('today');
+        $workspaceId = $this->option('workspace_id');
+
+        $query = UserInvoice::whereNotNull('due_date')
+            ->whereNotIn('status', array(
+                PaymentStatus::PAID,
+                PaymentStatus::REFUNDED,
+                PaymentStatus::CANCELLED,
+                'COMPLETE',
+                'REFUNDED',
+                'CANCELLED',
+            ));
+
+        if (!empty($workspaceId)) {
+            $query->where('workspace_id', $workspaceId);
+        }
+
+        $invoices = $query->orderBy('due_date', 'asc')->get();
+        $suspended = 0;
+
+        foreach ($invoices as $invoice) {
+            if (empty($invoice->workspace_id) || empty($invoice->due_date)) {
+                continue;
+            }
+
+            $dueDate = $invoice->due_date instanceof \DateTimeInterface
+                ? new DateTime($invoice->due_date->format('Y-m-d'))
+                : new DateTime((string) $invoice->due_date);
+
+            if ($dueDate >= $today) {
+                continue;
+            }
+
+            $daysPastDue = (int) $dueDate->diff($today)->days;
+            $threshold = WorkspaceSuspensionHelper::getGracePeriodThresholdForWorkspace($invoice->workspace_id);
+
+            if ($daysPastDue <= $threshold) {
+                continue;
+            }
+
+            $workspace = Workspace::find($invoice->workspace_id);
+            if (!$workspace) {
+                continue;
+            }
+
+            WorkspaceSuspensionHelper::suspendWorkspace($workspace, $invoice, $daysPastDue, $threshold);
+            $suspended++;
+
+            $this->info(sprintf(
+                'Suspended workspace #%d: invoice #%d is %d days past due, threshold is %d days.',
+                $workspace->id,
+                $invoice->id,
+                $daysPastDue,
+                $threshold
+            ));
+        }
+
+        $this->info(sprintf('Done. Suspended %d workspace(s).', $suspended));
+    }
+}

--- a/app/app/Helpers/RabbitMQHelper.php
+++ b/app/app/Helpers/RabbitMQHelper.php
@@ -11,6 +11,9 @@ class RabbitMQHelper
 {
     const INVOICE_QUEUE_MONTHLY = 'monthly_invoices';
     const INVOICE_QUEUE_ANNUAL = 'annual_invoices';
+    const BILLING_EVENTS_EXCHANGE = 'billing.events';
+    const WORKSPACE_SUSPENDED_QUEUE = 'workspace_account_suspended';
+    const WORKSPACE_SUSPENDED_ROUTING_KEY = 'workspace.account.suspended';
 
     /**
      * Generic method to publish a message to any RabbitMQ queue.
@@ -53,6 +56,68 @@ class RabbitMQHelper
             // so the Controller knows the billing task failed to queue.
             throw $e; 
         }
+    }
+
+    public static function publishToExchange($exchange, $routingKey, array $payload, $exchangeType = 'topic')
+    {
+        try {
+            $connection = new AMQPStreamConnection(
+                env('RABBITMQ_HOST', 'localhost'),
+                env('RABBITMQ_PORT', 5672),
+                env('RABBITMQ_USER', 'guest'),
+                env('RABBITMQ_PASSWORD', 'guest')
+            );
+            $channel = $connection->channel();
+
+            $channel->exchange_declare($exchange, $exchangeType, false, true, false);
+
+            $msg = new AMQPMessage(
+                json_encode($payload),
+                [
+                    'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
+                    'content_type'  => 'application/json'
+                ]
+            );
+
+            $channel->basic_publish($msg, $exchange, $routingKey);
+
+            $channel->close();
+            $connection->close();
+
+            Log::info("RabbitMQ published to {$exchange} with routing key {$routingKey}: " . json_encode($payload));
+        } catch (Exception $e) {
+            Log::error("RabbitMQ Publish Error on exchange {$exchange}: " . $e->getMessage());
+            throw $e;
+        }
+    }
+
+    public static function dispatchWorkspaceSuspended($workspace, $suspension, $owner = null)
+    {
+        if (!$owner && $workspace && !empty($workspace->creator_id)) {
+            $owner = \App\User::find($workspace->creator_id);
+        }
+
+        $suspendedAt = $suspension && $suspension->suspended_at
+            ? $suspension->suspended_at->format('Y-m-d H:i:s')
+            : date('Y-m-d H:i:s');
+
+        $payload = [
+            'event' => 'workspace.suspended',
+            'timestamp' => gmdate('c'),
+            'data' => [
+                'workspace_id' => (int) $workspace->id,
+                'owner_email' => $owner ? $owner->email : null,
+                'suspended_at' => $suspendedAt,
+                'grace_period_extension_days' => $suspension ? $suspension->grace_period_extension : null,
+                'reason' => $suspension ? $suspension->reason : 'payment_past_due'
+            ]
+        ];
+
+        return self::publishToExchange(
+            self::BILLING_EVENTS_EXCHANGE,
+            self::WORKSPACE_SUSPENDED_ROUTING_KEY,
+            $payload
+        );
     }
 
     /**

--- a/app/app/Helpers/WorkspaceHelper.php
+++ b/app/app/Helpers/WorkspaceHelper.php
@@ -146,7 +146,10 @@ case 'create_trunks':
       ));
       $data = $acls->get()->toArray(); 
       foreach ( $data as $cnt => $row ) {
-        $acl = WorkspaceRoutingACL::where('routing_acl_id',$row['routing_acl_id'])->first();
+        $data[$cnt]['enabled'] = $row['preset_acl_enabled'];
+        $acl = WorkspaceRoutingACL::where('routing_acl_id', $row['routing_acl_id'])
+          ->where('workspace_id', $workspace->id)
+          ->first();
         if ( $acl ) {
           $data[$cnt]['workspace_acl_id'] = $acl->id;
           $data[$cnt]['enabled'] = $acl->enabled;

--- a/app/app/Helpers/WorkspaceSuspensionHelper.php
+++ b/app/app/Helpers/WorkspaceSuspensionHelper.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Customizations;
+use App\Workspace;
+use App\WorkspaceSuspension;
+use DateTime;
+use Schema;
+
+final class WorkspaceSuspensionHelper
+{
+    public static function getGlobalGracePeriod()
+    {
+        $customizations = Customizations::getRecord();
+        if ($customizations && $customizations->grace_period_billing_days !== null) {
+            return (int) $customizations->grace_period_billing_days;
+        }
+
+        return 7;
+    }
+
+    public static function getActiveSuspension($workspaceId)
+    {
+        if (!Schema::hasTable('workspace_suspensions')) {
+            return null;
+        }
+
+        $query = WorkspaceSuspension::where('workspace_id', $workspaceId)
+            ->where('status', true);
+
+        return $query->orderBy('suspended_at', 'desc')->first();
+    }
+
+    public static function getGracePeriodExtension($workspaceId)
+    {
+        $suspension = self::getActiveSuspension($workspaceId);
+
+        if ($suspension && $suspension->grace_period_extension !== null) {
+            return (int) $suspension->grace_period_extension;
+        }
+
+        return null;
+    }
+
+    public static function getGracePeriodThresholdForWorkspace($workspaceId)
+    {
+        $extension = self::getGracePeriodExtension($workspaceId);
+        if ($extension !== null) {
+            return $extension;
+        }
+
+        return self::getGlobalGracePeriod();
+    }
+
+    public static function saveGracePeriodExtension(Workspace $workspace, $value)
+    {
+        if (!Schema::hasTable('workspace_suspensions')) {
+            return null;
+        }
+
+        $extension = null;
+        if ($value !== null && $value !== '') {
+            $extension = (int) $value;
+        }
+
+        $suspension = self::getActiveSuspension($workspace->id);
+        if (!$suspension) {
+            return null;
+        }
+
+        $suspension->grace_period_extension = $extension;
+        $suspension->save();
+
+        return $suspension;
+    }
+
+    public static function suspendWorkspace(Workspace $workspace, $invoice = null, $daysPastDue = null, $threshold = null)
+    {
+        if (!Schema::hasTable('workspace_suspensions')) {
+            return null;
+        }
+
+        $suspension = self::getActiveSuspension($workspace->id);
+        if (!$suspension) {
+            $suspension = new WorkspaceSuspension();
+            $suspension->workspace_id = $workspace->id;
+            $suspension->suspended_at = new DateTime();
+            $suspension->reason = 'payment_past_due';
+            $suspension->status = true;
+        }
+
+        if (!$suspension->suspended_at) {
+            $suspension->suspended_at = new DateTime();
+        }
+        if (!$suspension->reason) {
+            $suspension->reason = 'payment_past_due';
+        }
+        $suspension->status = true;
+
+        $suspension->save();
+
+        if ($workspace->active) {
+            $workspace->active = false;
+            $workspace->save();
+        }
+
+        return $suspension;
+    }
+}

--- a/app/app/Helpers/WorkspaceSuspensionHelper.php
+++ b/app/app/Helpers/WorkspaceSuspensionHelper.php
@@ -6,6 +6,7 @@ use App\Customizations;
 use App\Workspace;
 use App\WorkspaceSuspension;
 use DateTime;
+use Log;
 use Schema;
 
 final class WorkspaceSuspensionHelper
@@ -34,6 +35,13 @@ final class WorkspaceSuspensionHelper
 
     public static function getGracePeriodExtension($workspaceId)
     {
+        if (Schema::hasColumn('workspaces', 'grace_period_extension')) {
+            $workspace = Workspace::find($workspaceId);
+            if ($workspace && $workspace->grace_period_extension !== null) {
+                return (int) $workspace->grace_period_extension;
+            }
+        }
+
         $suspension = self::getActiveSuspension($workspaceId);
 
         if ($suspension && $suspension->grace_period_extension !== null) {
@@ -55,18 +63,23 @@ final class WorkspaceSuspensionHelper
 
     public static function saveGracePeriodExtension(Workspace $workspace, $value)
     {
-        if (!Schema::hasTable('workspace_suspensions')) {
-            return null;
-        }
-
         $extension = null;
         if ($value !== null && $value !== '') {
             $extension = (int) $value;
         }
 
+        if (Schema::hasColumn('workspaces', 'grace_period_extension')) {
+            $workspace->grace_period_extension = $extension;
+            $workspace->save();
+        }
+
+        if (!Schema::hasTable('workspace_suspensions')) {
+            return $workspace;
+        }
+
         $suspension = self::getActiveSuspension($workspace->id);
         if (!$suspension) {
-            return null;
+            return $workspace;
         }
 
         $suspension->grace_period_extension = $extension;
@@ -82,12 +95,14 @@ final class WorkspaceSuspensionHelper
         }
 
         $suspension = self::getActiveSuspension($workspace->id);
+        $isNewSuspension = false;
         if (!$suspension) {
             $suspension = new WorkspaceSuspension();
             $suspension->workspace_id = $workspace->id;
             $suspension->suspended_at = new DateTime();
             $suspension->reason = 'payment_past_due';
             $suspension->status = true;
+            $isNewSuspension = true;
         }
 
         if (!$suspension->suspended_at) {
@@ -103,6 +118,17 @@ final class WorkspaceSuspensionHelper
         if ($workspace->active) {
             $workspace->active = false;
             $workspace->save();
+        }
+
+        if ($isNewSuspension) {
+            try {
+                RabbitMQHelper::dispatchWorkspaceSuspended($workspace, $suspension);
+            } catch (\Exception $e) {
+                Log::error('Failed to publish workspace suspension event: ' . $e->getMessage(), [
+                    'workspace_id' => $workspace->id,
+                    'suspension_id' => $suspension->id
+                ]);
+            }
         }
 
         return $suspension;

--- a/app/app/Http/Controllers/Admin/WorkspaceController.php
+++ b/app/app/Http/Controllers/Admin/WorkspaceController.php
@@ -19,6 +19,7 @@ use Datatables;
 use DB;
 use Config;
 use Mail;
+use Schema;
 use Illuminate\Http\Request;
 
 class WorkspaceController extends AdminController
@@ -47,7 +48,8 @@ class WorkspaceController extends AdminController
     public function create()
     {
         $gracePeriodExtension = null;
-        return view('admin.workspace.create_edit', compact('gracePeriodExtension'));
+        $activeSuspension = null;
+        return view('admin.workspace.create_edit', compact('gracePeriodExtension', 'activeSuspension'));
     }
 
     /**
@@ -83,7 +85,8 @@ class WorkspaceController extends AdminController
         $routingACLs = WorkspaceHelper::getACLs($workspace);
         $planHistory = PlanUsagePeriod::where("workspace_id", $workspace->id)->get();
         $gracePeriodExtension = WorkspaceSuspensionHelper::getGracePeriodExtension($workspace->id);
-        return view('admin.workspace.create_edit', compact('workspace', 'users', 'billingHistory', 'billingInfo', 'usageTriggers', 'routingACLs', 'planHistory', 'invoices', 'gracePeriodExtension'));
+        $activeSuspension = WorkspaceSuspensionHelper::getActiveSuspension($workspace->id);
+        return view('admin.workspace.create_edit', compact('workspace', 'users', 'billingHistory', 'billingInfo', 'usageTriggers', 'routingACLs', 'planHistory', 'invoices', 'gracePeriodExtension', 'activeSuspension'));
     }
 
     /**
@@ -129,14 +132,37 @@ class WorkspaceController extends AdminController
      */
     public function data()
     {
-        $workspaces = DB::table('workspaces')->select(array('workspaces.id', 'workspaces.name', 'workspaces.active', 'workspaces.created_at'));
+        $globalGracePeriod = WorkspaceSuspensionHelper::getGlobalGracePeriod();
+        $activeSuspensionSelect = Schema::hasTable('workspace_suspensions')
+            ? DB::raw('(select count(*) from workspace_suspensions ws_status where ws_status.workspace_id = workspaces.id and ws_status.status = 1) as active_suspension')
+            : DB::raw('0 as active_suspension');
+        $gracePeriodSources = array();
+        if (Schema::hasColumn('workspaces', 'grace_period_extension')) {
+            $gracePeriodSources[] = 'workspaces.grace_period_extension';
+        }
+        if (Schema::hasTable('workspace_suspensions')) {
+            $gracePeriodSources[] = '(select ws.grace_period_extension from workspace_suspensions ws where ws.workspace_id = workspaces.id and ws.status = 1 and ws.grace_period_extension is not null order by ws.suspended_at desc limit 1)';
+        }
+        $gracePeriodSources[] = (int) $globalGracePeriod;
+        $gracePeriodSelect = DB::raw('COALESCE(' . implode(', ', $gracePeriodSources) . ') as grace_period');
+
+        $workspaces = DB::table('workspaces')->select(array(
+            'workspaces.id',
+            'workspaces.name',
+            'workspaces.active',
+            $gracePeriodSelect,
+            'workspaces.created_at',
+            $activeSuspensionSelect
+        ));
 
         return Datatables::of($workspaces)
-            ->edit_column('active', '@if ($active=="1") <span class="glyphicon glyphicon-ok"></span> @else <span class=\'glyphicon glyphicon-remove\'></span> @endif')
+            ->edit_column('active', '@if ($active_suspension > 0) <span class="label label-danger">Suspended</span> @elseif ($active=="1") <span class="glyphicon glyphicon-ok"></span> @else <span class=\'glyphicon glyphicon-remove\'></span> @endif')
+            ->edit_column('grace_period', '{{ $grace_period }} days')
             ->add_column('actions', '<a href="{{{ url(\'admin/workspace/\' . $id . \'/edit\' ) }}}" class="btn btn-success btn-sm iframe" ><span class="glyphicon glyphicon-pencil"></span>  {{ trans("admin/modal.edit") }}</a>
             <a href="{{{ url(\'admin/supportticket/?workspace_id=\' . $id) }}}" class="btn btn-success btn-sm" ><span class="glyphicon glyphicon-headphones"></span>  {{ trans("admin/modal.support_tickets") }}</a>
                     <a href="{{{ url(\'admin/workspace/\' . $id . \'/delete\' ) }}}" class="btn btn-sm btn-danger iframe"><span class="glyphicon glyphicon-trash"></span> {{ trans("admin/modal.delete") }}</a>')
             ->remove_column('id')
+            ->remove_column('active_suspension')
             ->make();
     }
 

--- a/app/app/Http/Controllers/Admin/WorkspaceController.php
+++ b/app/app/Http/Controllers/Admin/WorkspaceController.php
@@ -14,6 +14,7 @@ use App\Http\Requests\Admin\WorkspaceRequest;
 use App\Helpers\MainHelper;
 use App\Helpers\WorkspaceHelper;
 use App\Helpers\BillingDataHelper;
+use App\Helpers\WorkspaceSuspensionHelper;
 use Datatables;
 use DB;
 use Config;
@@ -45,7 +46,8 @@ class WorkspaceController extends AdminController
      */
     public function create()
     {
-        return view('admin.workspace.create_edit');
+        $gracePeriodExtension = null;
+        return view('admin.workspace.create_edit', compact('gracePeriodExtension'));
     }
 
     /**
@@ -56,8 +58,9 @@ class WorkspaceController extends AdminController
     public function store(WorkspaceRequest $request)
     {
 
-        $workspace = new Workspace($request->all());
+        $workspace = new Workspace($request->except('grace_period_extension'));
         $workspace->save();
+        WorkspaceSuspensionHelper::saveGracePeriodExtension($workspace, $request->input('grace_period_extension'));
         header("X-Goto-URL: /admin/workspace/" . $workspace->id . "/edit");
     }
 
@@ -79,7 +82,8 @@ class WorkspaceController extends AdminController
         $usageTriggers = UsageTrigger::where("workspace_id", $workspace->id)->get();
         $routingACLs = WorkspaceHelper::getACLs($workspace);
         $planHistory = PlanUsagePeriod::where("workspace_id", $workspace->id)->get();
-        return view('admin.workspace.create_edit', compact('workspace', 'users', 'billingHistory', 'billingInfo', 'usageTriggers', 'routingACLs', 'planHistory', 'invoices'));
+        $gracePeriodExtension = WorkspaceSuspensionHelper::getGracePeriodExtension($workspace->id);
+        return view('admin.workspace.create_edit', compact('workspace', 'users', 'billingHistory', 'billingInfo', 'usageTriggers', 'routingACLs', 'planHistory', 'invoices', 'gracePeriodExtension'));
     }
 
     /**
@@ -90,7 +94,8 @@ class WorkspaceController extends AdminController
      */
     public function update(WorkspaceRequest $request, Workspace $workspace)
     {
-        $workspace->update($request->all());
+        $workspace->update($request->except('grace_period_extension'));
+        WorkspaceSuspensionHelper::saveGracePeriodExtension($workspace, $request->input('grace_period_extension'));
         header("X-Goto-URL: /admin/workspace/" . $workspace->id . "/edit");
     }
 

--- a/app/app/Http/Requests/Admin/WorkspaceRequest.php
+++ b/app/app/Http/Requests/Admin/WorkspaceRequest.php
@@ -1,0 +1,20 @@
+<?php namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WorkspaceRequest extends FormRequest
+{
+    public function rules()
+    {
+        return array(
+            'name' => 'required',
+            'active' => 'required',
+            'grace_period_extension' => 'integer|min:0',
+        );
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}

--- a/app/app/Workspace.php
+++ b/app/app/Workspace.php
@@ -15,7 +15,8 @@ class Workspace extends Model {
   protected $guarded  = array('id');
   protected $table = "workspaces";
   protected $casts = array(
-    "byo_enabled" => "boolean"
+    "byo_enabled" => "boolean",
+    "grace_period_extension" => "integer"
     );
   public function toArray() {
         $array = parent::toArray();

--- a/app/app/WorkspaceSuspension.php
+++ b/app/app/WorkspaceSuspension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WorkspaceSuspension extends Model
+{
+    public $timestamps = false;
+
+    protected $dates = ['suspended_at'];
+
+    protected $guarded = array('id');
+    protected $table = 'workspace_suspensions';
+    protected $casts = array(
+        'status' => 'boolean',
+        'grace_period_extension' => 'integer',
+    );
+}

--- a/app/database/migrations/2026_05_22_000001_add_grace_period_extension_to_workspace_suspensions.php
+++ b/app/database/migrations/2026_05_22_000001_add_grace_period_extension_to_workspace_suspensions.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGracePeriodExtensionToWorkspaceSuspensions extends Migration
+{
+    public function up()
+    {
+        if (Schema::hasTable('workspace_suspensions')) {
+            return;
+        }
+
+        Schema::create('workspace_suspensions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('workspace_id')->unsigned();
+            $table->timestamp('suspended_at');
+            $table->integer('grace_period_extension')->nullable();
+            $table->string('reason');
+            $table->boolean('status')->default(true);
+
+            $table->foreign('workspace_id')->references('id')->on('workspaces')->onDelete('CASCADE');
+            $table->index(array('workspace_id', 'status'));
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('workspace_suspensions');
+    }
+}

--- a/app/database/migrations/2026_05_22_000002_add_grace_period_extension_to_workspaces.php
+++ b/app/database/migrations/2026_05_22_000002_add_grace_period_extension_to_workspaces.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGracePeriodExtensionToWorkspaces extends Migration
+{
+    public function up()
+    {
+        if (!Schema::hasColumn('workspaces', 'grace_period_extension')) {
+            Schema::table('workspaces', function (Blueprint $table) {
+                $table->integer('grace_period_extension')->nullable()->after('active');
+            });
+        }
+    }
+
+    public function down()
+    {
+        if (Schema::hasColumn('workspaces', 'grace_period_extension')) {
+            Schema::table('workspaces', function (Blueprint $table) {
+                $table->dropColumn('grace_period_extension');
+            });
+        }
+    }
+}

--- a/app/resources/views/admin/workspace/create_edit.blade.php
+++ b/app/resources/views/admin/workspace/create_edit.blade.php
@@ -49,6 +49,24 @@
                 <span class="help-block">{{ $errors->first('confirmed', ':message') }}</span>
             </div>
         </div>
+        @if (isset($workspace))
+        <div class="form-group">
+            {!! Form::label('workspace_status', 'Status', array('class' => 'control-label')) !!}
+            <div class="controls">
+                @if (!empty($activeSuspension))
+                    <span class="label label-danger" style="font-size: 13px; display: inline-block; padding: 6px 10px;">Suspended</span>
+                    <span class="help-block">
+                        Reason: {{ $activeSuspension->reason }}.
+                        Suspended at: {{ $activeSuspension->suspended_at }}.
+                    </span>
+                @elseif (!empty($workspace->active))
+                    <span class="label label-success" style="font-size: 13px; display: inline-block; padding: 6px 10px;">Active</span>
+                @else
+                    <span class="label label-default" style="font-size: 13px; display: inline-block; padding: 6px 10px;">Inactive</span>
+                @endif
+            </div>
+        </div>
+        @endif
         <div class="form-group">
             <button type="submit" class="btn btn-sm btn-success">
                 <span class="glyphicon glyphicon-ok-circle"></span>
@@ -61,7 +79,7 @@
         <div class="form-group {{ $errors->has('grace_period_extension') ? 'has-error' : '' }}">
             {!! Form::label('grace_period_extension', 'Extend Grace Period (Days)', array('class' => 'control-label')) !!}
             <div class="controls">
-                {!! Form::number('grace_period_extension', $gracePeriodExtension, array('class' => 'form-control', 'min' => '0', 'placeholder' => 'Defaults to global system setting (7 days) if left blank.')) !!}
+                {!! Form::number('grace_period_extension', old('grace_period_extension', $gracePeriodExtension), array('class' => 'form-control', 'min' => '0', 'placeholder' => 'Defaults to global system setting (7 days) if left blank.')) !!}
                 <span class="help-block">Defaults to global system setting (7 days) if left blank.</span>
                 <span class="help-block">{{ $errors->first('grace_period_extension', ':message') }}</span>
             </div>

--- a/app/resources/views/admin/workspace/create_edit.blade.php
+++ b/app/resources/views/admin/workspace/create_edit.blade.php
@@ -6,6 +6,9 @@
     <li class="active">
         <a href="#tab-general" data-toggle="tab">{{ trans("admin/modal.general") }}</a>
     </li>
+    <li>
+        <a href="#tab-grace-periods" data-toggle="tab">Grace Periods</a>
+    </li>
     @if (!empty($workspace))
     <li>
         <a href="#tab-users" data-toggle="tab">{{ trans("admin/modal.users") }}</a>
@@ -44,6 +47,23 @@
                 {!! Form::label('active', trans("admin/admin.no"), array('class' => 'control-label')) !!}
                 {!! Form::radio('active', '0', @isset($workspace)? $workspace->active : 'true') !!}
                 <span class="help-block">{{ $errors->first('confirmed', ':message') }}</span>
+            </div>
+        </div>
+        <div class="form-group">
+            <button type="submit" class="btn btn-sm btn-success">
+                <span class="glyphicon glyphicon-ok-circle"></span>
+                {{ isset($workspace) ? trans("admin/modal.edit") : trans("admin/modal.create") }}
+            </button>
+        </div>
+    </div>
+
+    <div class="tab-pane" id="tab-grace-periods">
+        <div class="form-group {{ $errors->has('grace_period_extension') ? 'has-error' : '' }}">
+            {!! Form::label('grace_period_extension', 'Extend Grace Period (Days)', array('class' => 'control-label')) !!}
+            <div class="controls">
+                {!! Form::number('grace_period_extension', $gracePeriodExtension, array('class' => 'form-control', 'min' => '0', 'placeholder' => 'Defaults to global system setting (7 days) if left blank.')) !!}
+                <span class="help-block">Defaults to global system setting (7 days) if left blank.</span>
+                <span class="help-block">{{ $errors->first('grace_period_extension', ':message') }}</span>
             </div>
         </div>
         <div class="form-group">

--- a/app/resources/views/admin/workspace/index.blade.php
+++ b/app/resources/views/admin/workspace/index.blade.php
@@ -21,6 +21,7 @@
         <tr>
             <th>{!! trans("admin/workspaces.name") !!}</th>
             <th>{!! trans("admin/workspaces.active") !!}</th>
+            <th>Grace Period</th>
             <th>{!! trans("admin/admin.created_at") !!}</th>
             <th>{!! trans("admin/admin.action") !!}</th>
         </tr>

--- a/app/resources/views/emails/workspace_account_suspended.blade.php
+++ b/app/resources/views/emails/workspace_account_suspended.blade.php
@@ -1,0 +1,62 @@
+@extends('emails.layouts.header')
+@section('title')
+Account Suspended
+@endsection
+@section('content')
+
+<tr>
+    <td valign="top" class="mobilespacer">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+            <tbody>
+                <tr>
+                    <td width="30" class="hide">&nbsp;</td>
+                    <td class="mobilespacer2">
+                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                            <tbody>
+                                <tr>
+                                    <td valign="top" height="12" style="mso-line-height-rule:exactly;font-size:1px;line-height:12px;">&nbsp;</td>
+                                </tr>
+                                <tr>
+                                    <td bgcolor="#ffffff" valign="top" height="3" style="mso-line-height-rule:exactly;font-size:1px;line-height:3px;border-top:2px solid #f4f7fa;">&nbsp;</td>
+                                </tr>
+                                <tr>
+                                    <td valign="top" style="padding:22px 30px 18px;font-family:Arial, Helvetica Neue, Helvetica, sans-serif;color:#393d47;font-size:16px;line-height:24px;text-align:left;">
+                                        <h2 style="margin:0 0 8px;font-size:24px;line-height:30px;color:#0a1247;font-weight:700;">Your workspace has been suspended</h2>
+                                        <p style="margin:0;">Dear {{ $owner ? $owner->getName() : 'Customer' }},</p>
+                                        <p style="margin:12px 0 0;color:#5f6b7a;">Your workspace access has been suspended because billing is past due. Please update your billing information or pay the outstanding invoice to restore service.</p>
+
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin-top:18px;border:1px solid #e5e7eb;border-radius:6px;">
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;width:42%;">Workspace</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;font-weight:700;word-break:break-word;">{{ $workspace->name }} (#{{ $workspace_id }})</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Suspended At</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $suspended_at }}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Reason</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $reason }}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;font-size:13px;line-height:20px;color:#6b7280;">Grace Period Extension</td>
+                                                <td style="padding:12px 16px;font-size:15px;line-height:20px;color:#111827;">{{ $grace_period_extension_days === null ? 'None' : $grace_period_extension_days . ' days' }}</td>
+                                            </tr>
+                                        </table>
+
+                                        <p style="margin:18px 0 0;color:#5f6b7a;font-size:14px;line-height:22px;">After payment is resolved, contact support if your workspace is not restored automatically.</p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <td width="30" class="hide">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="line-height:1px;mso-line-height-rule:exactly;font-size:0;" height="16">&nbsp;</td>
+                </tr>
+            </tbody>
+        </table>
+    </td>
+</tr>
+@endsection

--- a/app/resources/views/emails/workspace_suspended_admin.blade.php
+++ b/app/resources/views/emails/workspace_suspended_admin.blade.php
@@ -1,0 +1,63 @@
+@extends('emails.layouts.header')
+@section('title')
+Workspace Suspended
+@endsection
+@section('content')
+
+<tr>
+    <td valign="top" class="mobilespacer">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+            <tbody>
+                <tr>
+                    <td width="30" class="hide">&nbsp;</td>
+                    <td class="mobilespacer2">
+                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                            <tbody>
+                                <tr>
+                                    <td valign="top" height="12" style="mso-line-height-rule:exactly;font-size:1px;line-height:12px;">&nbsp;</td>
+                                </tr>
+                                <tr>
+                                    <td bgcolor="#ffffff" valign="top" height="3" style="mso-line-height-rule:exactly;font-size:1px;line-height:3px;border-top:2px solid #f4f7fa;">&nbsp;</td>
+                                </tr>
+                                <tr>
+                                    <td valign="top" style="padding:22px 30px 18px;font-family:Arial, Helvetica Neue, Helvetica, sans-serif;color:#393d47;font-size:16px;line-height:24px;text-align:left;">
+                                        <h2 style="margin:0 0 8px;font-size:24px;line-height:30px;color:#0a1247;font-weight:700;">Workspace suspension received</h2>
+                                        <p style="margin:0;color:#5f6b7a;">A workspace suspension event was received and processed.</p>
+
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin-top:18px;border:1px solid #e5e7eb;border-radius:6px;">
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;width:42%;">Workspace</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;font-weight:700;word-break:break-word;">{{ $workspace->name }} (#{{ $workspace_id }})</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Owner Email</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $owner ? $owner->email : (isset($event_data['owner_email']) ? $event_data['owner_email'] : 'Unknown') }}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Suspended At</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $suspended_at }}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Reason</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $reason }}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;font-size:13px;line-height:20px;color:#6b7280;">Grace Period Extension</td>
+                                                <td style="padding:12px 16px;font-size:15px;line-height:20px;color:#111827;">{{ $grace_period_extension_days === null ? 'None' : $grace_period_extension_days . ' days' }}</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <td width="30" class="hide">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="line-height:1px;mso-line-height-rule:exactly;font-size:0;" height="16">&nbsp;</td>
+                </tr>
+            </tbody>
+        </table>
+    </td>
+</tr>
+@endsection


### PR DESCRIPTION
**Added a new Artisan command:**

- billing:suspend-past-due-workspaces
- Checks unpaid workspace invoices
- Compares invoice overdue duration against configured grace periods
- Suspends workspaces when the allowed grace period is exceeded

**Added support for configurable grace periods:**

- Uses the global customization setting by default
- Supports workspace-specific grace period extensions

**Extended the workspace admin edit UI:**

- Added a new Grace Periods tab
- Allows admins to view and update workspace grace period extension values

**Updated workspace create/update handling:**

- Added validation for grace period extension input
- Prevented the value from being written directly into the main workspace payload

**Added workspace suspension tracking:**

- Introduced workspace_suspensions table
- Added model/helper logic for:
- suspension reason
- suspension date
- suspension status
- grace period extension tracking

**Improved ACL override lookup:**

- Workspace routing ACL overrides are now scoped by workspace_id