### PR TITLE
Add workspace suspension RabbitMQ email notifications

### DIFF
--- a/app/app/Console/Commands/RabbitMQEventConsumer.php
+++ b/app/app/Console/Commands/RabbitMQEventConsumer.php
@@ -10,6 +10,9 @@ use App\Helpers\RabbitMQHelper;
 use App\Helpers\WorkspaceInvoiceHelper;
 use App\User;
 use App\Workspace;
+use App\WorkspaceUser;
+use App\Mail\WorkspaceSuspendedNotification;
+use Carbon\Carbon;
 use Exception;
 use Log;
 
@@ -53,8 +56,14 @@ class RabbitMQEventConsumer extends Command
         $channel->queue_declare(RabbitMQHelper::INVOICE_QUEUE_ANNUAL, false, true, false, false);
         $channel->exchange_declare(RabbitMQHelper::BILLING_EVENTS_EXCHANGE, 'topic', false, true, false);
         $channel->queue_declare(RabbitMQHelper::WORKSPACE_SUSPENDED_QUEUE, false, true, false, false);
+        $channel->queue_declare(RabbitMQHelper::WORKSPACE_SUSPENDED_LEGACY_QUEUE, false, true, false, false);
         $channel->queue_bind(
             RabbitMQHelper::WORKSPACE_SUSPENDED_QUEUE,
+            RabbitMQHelper::BILLING_EVENTS_EXCHANGE,
+            RabbitMQHelper::WORKSPACE_SUSPENDED_ROUTING_KEY
+        );
+        $channel->queue_bind(
+            RabbitMQHelper::WORKSPACE_SUSPENDED_LEGACY_QUEUE,
             RabbitMQHelper::BILLING_EVENTS_EXCHANGE,
             RabbitMQHelper::WORKSPACE_SUSPENDED_ROUTING_KEY
         );
@@ -73,6 +82,7 @@ class RabbitMQEventConsumer extends Command
         $channel->basic_consume(RabbitMQHelper::INVOICE_QUEUE_MONTHLY, '', false, false, false, false, [$this, 'handleMonthlyInvoiceTask']);
         $channel->basic_consume(RabbitMQHelper::INVOICE_QUEUE_ANNUAL, '', false, false, false, false, [$this, 'handleAnnualInvoiceTask']);
         $channel->basic_consume(RabbitMQHelper::WORKSPACE_SUSPENDED_QUEUE, '', false, false, false, false, [$this, 'handleWorkspaceSuspended']);
+        $channel->basic_consume(RabbitMQHelper::WORKSPACE_SUSPENDED_LEGACY_QUEUE, '', false, false, false, false, [$this, 'handleWorkspaceSuspended']);
 
         // 3. Keep the process alive
         while (count($channel->callbacks)) {
@@ -409,78 +419,72 @@ class RabbitMQEventConsumer extends Command
             return;
         }
 
-        if (!isset($payload['event']) || $payload['event'] !== 'workspace.suspended') {
-            $event = isset($payload['event']) ? $payload['event'] : 'missing';
-            $this->logConsumerError(' [WORKSPACE_SUSPENDED] Unsupported event: ' . $event, [
-                'payload' => $payload
-            ]);
-            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
-            return;
-        }
-
-        $data = isset($payload['data']) && is_array($payload['data']) ? $payload['data'] : array();
+        $data = $this->normalizeWorkspaceSuspendedPayload($payload);
         $workspaceId = isset($data['workspace_id']) ? (int) $data['workspace_id'] : 0;
         if ($workspaceId <= 0) {
             $this->logConsumerError(' [WORKSPACE_SUSPENDED] Missing workspace_id.', [
                 'payload' => $payload
             ]);
-            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            $this->rejectRabbitMessage($msg);
             return;
         }
 
         $workspace = Workspace::find($workspaceId);
         if (!$workspace) {
-            $this->logConsumerError(sprintf(' [WORKSPACE_SUSPENDED] Workspace #%d not found.', $workspaceId));
-            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            $this->logConsumerError(sprintf(' [WORKSPACE_SUSPENDED] Workspace #%d not found. Rejecting message.', $workspaceId), [
+                'payload' => $payload
+            ]);
+            $this->rejectRabbitMessage($msg);
             return;
         }
 
         $owner = $workspace->creatorUser()->first();
-        $ownerEmail = !empty($data['owner_email']) ? $data['owner_email'] : ($owner ? $owner->email : null);
-        $adminEmail = $this->resolveSystemAdminEmail();
+        $recipientEmails = $this->resolveWorkspaceSuspensionRecipients($workspace, $owner);
+        if (empty($recipientEmails)) {
+            $this->logConsumerError(sprintf(' [WORKSPACE_SUSPENDED] No owner or admin email addresses found for workspace #%d. Rejecting message.', $workspaceId), [
+                'payload' => $payload
+            ]);
+            $this->rejectRabbitMessage($msg);
+            return;
+        }
+
+        $suspendedAt = isset($data['suspended_at']) ? (string) $data['suspended_at'] : '';
+        $formattedSuspendedAt = $this->formatSuspendedAt($suspendedAt);
+        $gracePeriodExtension = null;
+        if (array_key_exists('grace_period_extension', $data)) {
+            $gracePeriodExtension = $data['grace_period_extension'];
+        } elseif (array_key_exists('grace_period_extension_days', $data)) {
+            $gracePeriodExtension = $data['grace_period_extension_days'];
+        }
 
         $emailData = array(
             'workspace' => $workspace,
             'owner' => $owner,
             'event' => $payload,
             'event_data' => $data,
+            'reference_id' => isset($data['id']) ? $data['id'] : null,
             'workspace_id' => $workspaceId,
-            'suspended_at' => isset($data['suspended_at']) ? $data['suspended_at'] : '',
+            'suspended_at' => $suspendedAt,
+            'suspended_at_formatted' => $formattedSuspendedAt,
             'reason' => isset($data['reason']) ? $data['reason'] : 'payment_past_due',
-            'grace_period_extension_days' => array_key_exists('grace_period_extension_days', $data) ? $data['grace_period_extension_days'] : null
+            'grace_period_extension' => $gracePeriodExtension,
+            'status' => array_key_exists('status', $data) ? $data['status'] : null
         );
 
-        $ownerResult = TRUE;
-        if (!empty($ownerEmail)) {
-            $ownerResult = EmailHelper::sendEmail(
-                'Account Suspended: Billing Action Required',
-                $ownerEmail,
-                'workspace_account_suspended',
-                $emailData
-            );
-        } else {
-            $this->logConsumerError(sprintf(' [WORKSPACE_SUSPENDED] Owner email missing for workspace #%d.', $workspaceId));
-            $ownerResult = FALSE;
+        $failedRecipients = array();
+        foreach ($recipientEmails as $email) {
+            $result = WorkspaceSuspendedNotification::sendTo($email, $emailData);
+
+            if ($result !== TRUE) {
+                $failedRecipients[$email] = $result;
+            }
         }
 
-        $adminResult = TRUE;
-        if (!empty($adminEmail)) {
-            $adminResult = EmailHelper::sendEmail(
-                sprintf('Workspace #%d Suspended', $workspaceId),
-                $adminEmail,
-                'workspace_suspended_admin',
-                $emailData
-            );
-        } else {
-            $this->logConsumerError(' [WORKSPACE_SUSPENDED] System admin email could not be resolved.');
-            $adminResult = FALSE;
-        }
-
-        if ($ownerResult === TRUE && $adminResult === TRUE) {
+        if (empty($failedRecipients)) {
             $this->logConsumerInfo(sprintf(' [v] Workspace suspension emails sent for workspace #%d.', $workspaceId), [
                 'workspace_id' => $workspaceId,
-                'owner_email' => $ownerEmail,
-                'admin_email' => $adminEmail
+                'recipients' => $recipientEmails,
+                'reference_id' => isset($data['id']) ? $data['id'] : null
             ]);
             $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
             return;
@@ -488,9 +492,64 @@ class RabbitMQEventConsumer extends Command
 
         $this->logConsumerError(sprintf(' [!] Workspace suspension email failed for workspace #%d.', $workspaceId), [
             'workspace_id' => $workspaceId,
-            'owner_result' => $ownerResult,
-            'admin_result' => $adminResult
+            'failed_recipients' => $failedRecipients
         ]);
+    }
+
+    private function normalizeWorkspaceSuspendedPayload(array $payload)
+    {
+        if (isset($payload['event']) && $payload['event'] === 'workspace.suspended') {
+            return isset($payload['data']) && is_array($payload['data']) ? $payload['data'] : array();
+        }
+
+        return $payload;
+    }
+
+    private function resolveWorkspaceSuspensionRecipients($workspace, $owner)
+    {
+        $emails = array();
+
+        if ($owner && !empty($owner->email)) {
+            $emails[] = $owner->email;
+        }
+
+        $adminUsers = WorkspaceUser::select(array('users.email'))
+            ->join('users', 'users.id', '=', 'workspaces_users.user_id')
+            ->where('workspaces_users.workspace_id', '=', $workspace->id)
+            ->where(function ($query) {
+                $query->where('workspaces_users.manage_billing', '=', 1)
+                    ->orWhere('workspaces_users.manage_workspace', '=', 1);
+            })
+            ->get();
+
+        foreach ($adminUsers as $adminUser) {
+            if (!empty($adminUser->email)) {
+                $emails[] = $adminUser->email;
+            }
+        }
+
+        $emails = array_filter(array_unique($emails));
+        return array_values($emails);
+    }
+
+    private function formatSuspendedAt($suspendedAt)
+    {
+        if (empty($suspendedAt)) {
+            return 'Not provided';
+        }
+
+        try {
+            return Carbon::parse($suspendedAt)
+                ->timezone(config('app.timezone', 'UTC'))
+                ->format('F j, Y g:i A T');
+        } catch (Exception $e) {
+            return $suspendedAt;
+        }
+    }
+
+    private function rejectRabbitMessage($msg)
+    {
+        $msg->delivery_info['channel']->basic_reject($msg->delivery_info['delivery_tag'], false);
     }
 
     private function resolveSystemAdminEmail()

--- a/app/app/Helpers/RabbitMQHelper.php
+++ b/app/app/Helpers/RabbitMQHelper.php
@@ -12,7 +12,8 @@ class RabbitMQHelper
     const INVOICE_QUEUE_MONTHLY = 'monthly_invoices';
     const INVOICE_QUEUE_ANNUAL = 'annual_invoices';
     const BILLING_EVENTS_EXCHANGE = 'billing.events';
-    const WORKSPACE_SUSPENDED_QUEUE = 'workspace_account_suspended';
+    const WORKSPACE_SUSPENDED_QUEUE = 'workspace_suspended';
+    const WORKSPACE_SUSPENDED_LEGACY_QUEUE = 'workspace_account_suspended';
     const WORKSPACE_SUSPENDED_ROUTING_KEY = 'workspace.account.suspended';
 
     /**
@@ -98,19 +99,16 @@ class RabbitMQHelper
         }
 
         $suspendedAt = $suspension && $suspension->suspended_at
-            ? $suspension->suspended_at->format('Y-m-d H:i:s')
-            : date('Y-m-d H:i:s');
+            ? $suspension->suspended_at->format('c')
+            : date('c');
 
         $payload = [
-            'event' => 'workspace.suspended',
-            'timestamp' => gmdate('c'),
-            'data' => [
-                'workspace_id' => (int) $workspace->id,
-                'owner_email' => $owner ? $owner->email : null,
-                'suspended_at' => $suspendedAt,
-                'grace_period_extension_days' => $suspension ? $suspension->grace_period_extension : null,
-                'reason' => $suspension ? $suspension->reason : 'payment_past_due'
-            ]
+            'id' => $suspension ? (int) $suspension->id : null,
+            'workspace_id' => (int) $workspace->id,
+            'suspended_at' => $suspendedAt,
+            'grace_period_extension' => $suspension ? $suspension->grace_period_extension : null,
+            'reason' => $suspension ? $suspension->reason : 'payment_past_due',
+            'status' => true
         ];
 
         return self::publishToExchange(

--- a/app/app/Helpers/RabbitMQHelper.php
+++ b/app/app/Helpers/RabbitMQHelper.php
@@ -49,13 +49,13 @@ class RabbitMQHelper
 
             $channel->close();
             $connection->close();
-            
+
             Log::info("RabbitMQ published to {$queue}: " . json_encode($payload));
         } catch (Exception $e) {
             Log::error("RabbitMQ Publish Error on queue {$queue}: " . $e->getMessage());
             // In a production environment, you might want to throw this exception 
             // so the Controller knows the billing task failed to queue.
-            throw $e; 
+            throw $e;
         }
     }
 
@@ -98,12 +98,14 @@ class RabbitMQHelper
             $owner = \App\User::find($workspace->creator_id);
         }
 
-        $suspendedAt = $suspension && $suspension->suspended_at
-            ? $suspension->suspended_at->format('c')
-            : date('c');
+        if ($suspension && $suspension->suspended_at) {
+            $suspendedAt = $suspension->suspended_at->format('c');
+        } else {
+            $suspendedAt = date('c');
+        }
 
         $payload = [
-            'id' => $suspension ? (int) $suspension->id : null,
+            'id' => $suspension->id,
             'workspace_id' => (int) $workspace->id,
             'suspended_at' => $suspendedAt,
             'grace_period_extension' => $suspension ? $suspension->grace_period_extension : null,
@@ -199,5 +201,4 @@ class RabbitMQHelper
 
         return self::publish(self::INVOICE_QUEUE_ANNUAL, $payload);
     }
-    
 }

--- a/app/app/Mail/WorkspaceSuspendedNotification.php
+++ b/app/app/Mail/WorkspaceSuspendedNotification.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Mail;
+
+use App\Helpers\EmailHelper;
+
+class WorkspaceSuspendedNotification
+{
+    const SUBJECT = 'Account Suspended: Billing Action Required';
+    const TEMPLATE = 'workspace_account_suspended';
+
+    public static function sendTo($email, array $data)
+    {
+        return EmailHelper::sendEmail(
+            self::SUBJECT,
+            $email,
+            self::TEMPLATE,
+            $data
+        );
+    }
+}

--- a/app/resources/views/emails/workspace_account_suspended.blade.php
+++ b/app/resources/views/emails/workspace_account_suspended.blade.php
@@ -23,16 +23,20 @@ Account Suspended
                                     <td valign="top" style="padding:22px 30px 18px;font-family:Arial, Helvetica Neue, Helvetica, sans-serif;color:#393d47;font-size:16px;line-height:24px;text-align:left;">
                                         <h2 style="margin:0 0 8px;font-size:24px;line-height:30px;color:#0a1247;font-weight:700;">Your workspace has been suspended</h2>
                                         <p style="margin:0;">Dear {{ $owner ? $owner->getName() : 'Customer' }},</p>
-                                        <p style="margin:12px 0 0;color:#5f6b7a;">Your workspace access has been suspended because billing is past due. Please update your billing information or pay the outstanding invoice to restore service.</p>
+                                        <p style="margin:12px 0 0;color:#5f6b7a;">Your workspace access has been suspended. Please review the details below and contact support with the reference number if you need help restoring service.</p>
 
                                         <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin-top:18px;border:1px solid #e5e7eb;border-radius:6px;">
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;width:42%;">Suspension Reference</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;font-weight:700;word-break:break-word;">{{ $reference_id ? '#' . $reference_id : 'Not provided' }}</td>
+                                            </tr>
                                             <tr>
                                                 <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;width:42%;">Workspace</td>
                                                 <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;font-weight:700;word-break:break-word;">{{ $workspace->name }} (#{{ $workspace_id }})</td>
                                             </tr>
                                             <tr>
-                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Suspended At</td>
-                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $suspended_at }}</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Suspension Date</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $suspended_at_formatted }}</td>
                                             </tr>
                                             <tr>
                                                 <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Reason</td>
@@ -40,7 +44,7 @@ Account Suspended
                                             </tr>
                                             <tr>
                                                 <td style="padding:12px 16px;font-size:13px;line-height:20px;color:#6b7280;">Grace Period Extension</td>
-                                                <td style="padding:12px 16px;font-size:15px;line-height:20px;color:#111827;">{{ $grace_period_extension_days === null ? 'None' : $grace_period_extension_days . ' days' }}</td>
+                                                <td style="padding:12px 16px;font-size:15px;line-height:20px;color:#111827;">{{ $grace_period_extension === null ? 'None' : $grace_period_extension . ' days' }}</td>
                                             </tr>
                                         </table>
 

--- a/app/resources/views/emails/workspace_suspended_admin.blade.php
+++ b/app/resources/views/emails/workspace_suspended_admin.blade.php
@@ -26,6 +26,10 @@ Workspace Suspended
 
                                         <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin-top:18px;border:1px solid #e5e7eb;border-radius:6px;">
                                             <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;width:42%;">Suspension Reference</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;font-weight:700;word-break:break-word;">{{ $reference_id ? '#' . $reference_id : 'Not provided' }}</td>
+                                            </tr>
+                                            <tr>
                                                 <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;width:42%;">Workspace</td>
                                                 <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;font-weight:700;word-break:break-word;">{{ $workspace->name }} (#{{ $workspace_id }})</td>
                                             </tr>
@@ -34,8 +38,8 @@ Workspace Suspended
                                                 <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $owner ? $owner->email : (isset($event_data['owner_email']) ? $event_data['owner_email'] : 'Unknown') }}</td>
                                             </tr>
                                             <tr>
-                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Suspended At</td>
-                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $suspended_at }}</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Suspension Date</td>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:15px;line-height:20px;color:#111827;">{{ $suspended_at_formatted }}</td>
                                             </tr>
                                             <tr>
                                                 <td style="padding:12px 16px;border-bottom:1px solid #e5e7eb;font-size:13px;line-height:20px;color:#6b7280;">Reason</td>
@@ -43,7 +47,7 @@ Workspace Suspended
                                             </tr>
                                             <tr>
                                                 <td style="padding:12px 16px;font-size:13px;line-height:20px;color:#6b7280;">Grace Period Extension</td>
-                                                <td style="padding:12px 16px;font-size:15px;line-height:20px;color:#111827;">{{ $grace_period_extension_days === null ? 'None' : $grace_period_extension_days . ' days' }}</td>
+                                                <td style="padding:12px 16px;font-size:15px;line-height:20px;color:#111827;">{{ $grace_period_extension === null ? 'None' : $grace_period_extension . ' days' }}</td>
                                             </tr>
                                         </table>
                                     </td>


### PR DESCRIPTION
Implements workspace suspension notification handling in the Laravel RabbitMQ consumer.

Changes include:

- Consume workspace_suspended RabbitMQ messages.
- Parse suspension payloads and enrich them with workspace details.
- Resolve workspace owner/admin billing contacts.
- Dispatch suspension notification emails after successful enrichment.
- ACK messages only after email dispatch succeeds.
- Reject invalid/missing workspace messages for dead-letter handling.
- Update suspension email templates with reference ID, workspace name, formatted suspension date, reason, and grace period extension.